### PR TITLE
add styling for code blocks

### DIFF
--- a/css/main.sass
+++ b/css/main.sass
@@ -143,3 +143,11 @@ footer
   .front-page-banner
     flex-direction: column
     text-align: center
+
+
+// code blocks
+pre
+    background-color: #f9f9f9
+    border: 1px solid #ddd
+    padding: 1em
+    font-size: 14px


### PR DESCRIPTION
The blog imports bootstrap v4, which has some default styling for the code blocks (https://getbootstrap.com/docs/4.0/content/code/). I've added some background color to make it a little more legible. Let me know if this looks ok to you: 

### Before - Bootstrap styling
<img width="940" alt="Screenshot 2020-05-27 at 11 41 52 AM" src="https://user-images.githubusercontent.com/11793045/83003815-1e358900-a00f-11ea-9cea-55e8695b3816.png">

### After - Custom styling
<img width="792" alt="Screenshot 2020-05-27 at 11 38 30 AM" src="https://user-images.githubusercontent.com/11793045/83003516-b7b06b00-a00e-11ea-9342-a0ae75bc1df7.png">
