### PR TITLE
Enable syntax highlighting in code snippets

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -11,6 +11,7 @@
   <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="/css/syntax.css" />
   <script
   src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
   integrity="sha256-pasqAKBDmFT4eHoN2ndd6lN370kFiGUFyTiUHWhU7k8="


### PR DESCRIPTION
So far we only have one blogpost with code snippets.
But if things go according to my plans, we should have more soon :smile: 

### Before
![Screenshot from 2022-08-27 18-52-18](https://user-images.githubusercontent.com/2716069/187040231-dd685004-a534-404f-a1e4-5e8cf8ea91a8.png)


### After
![Screenshot from 2022-08-27 18-50-41](https://user-images.githubusercontent.com/2716069/187040247-92102ca9-fc29-4926-8bb7-faa1bb2c66f5.png)
